### PR TITLE
Expand edTech platform with course listing page

### DIFF
--- a/courses.html
+++ b/courses.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>All Courses - edTech</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <nav class="navbar">
+            <div class="logo">edTech</div>
+            <ul class="nav-links">
+                <li><a href="index.html">Home</a></li>
+                <li><a href="#" class="active">Courses</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <main>
+        <section class="course-list">
+            <h2>All Courses</h2>
+            <ul id="coursesContainer"></ul>
+        </section>
+    </main>
+
+    <footer>
+        <p>&copy; 2023 edTech Platform</p>
+    </footer>
+
+    <script src="script.js"></script>
+    <script src="courses.js"></script>
+</body>
+</html>

--- a/courses.js
+++ b/courses.js
@@ -1,0 +1,22 @@
+function renderCourseList() {
+  const container = document.getElementById('coursesContainer');
+  window.courses.forEach(course => {
+    const li = document.createElement('li');
+    li.className = 'course-item';
+    li.innerHTML = `<h3>${course.title}</h3><p>${course.description}</p><button class="enroll-btn" onclick="enroll(${course.id})">Enroll</button>`;
+    container.appendChild(li);
+  });
+}
+
+function enroll(courseId) {
+  let enrolled = JSON.parse(localStorage.getItem('enrolledCourses') || '[]');
+  if (!enrolled.includes(courseId)) {
+    enrolled.push(courseId);
+    localStorage.setItem('enrolledCourses', JSON.stringify(enrolled));
+    alert('Enrolled in course!');
+  } else {
+    alert('You are already enrolled in this course.');
+  }
+}
+
+window.addEventListener('DOMContentLoaded', renderCourseList);

--- a/index.html
+++ b/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>edTech Platform</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <nav class="navbar">
+            <div class="logo">edTech</div>
+            <ul class="nav-links">
+                <li><a href="#courses">Courses</a></li>
+                <li><a href="courses.html">All Courses</a></li>
+                <li><a href="#about">About</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <main>
+        <section class="hero">
+            <h1>Empower your future with online learning</h1>
+            <p>Learn at your own pace with our curated content.</p>
+        </section>
+
+        <section id="courses" class="courses">
+            <h2>Featured Lecture</h2>
+            <video controls width="600">
+                <source src="https://www.w3schools.com/html/mov_bbb.mp4" type="video/mp4">
+                Your browser does not support the video tag.
+            </video>
+            <h3>Introduction to Coding</h3>
+            <p>A brief overview of the basics of programming using JavaScript.</p>
+        </section>
+
+        <section class="course-list">
+            <h2>Available Courses</h2>
+            <ul id="courseContainer"></ul>
+        </section>
+    </main>
+
+    <footer id="about">
+        <p>&copy; 2023 edTech Platform</p>
+    </footer>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/readMe.md
+++ b/readMe.md
@@ -1,1 +1,9 @@
-Create a edtech platform.
+# edTech Platform
+
+This is a simple example of a small education technology web app. It provides a modern landing page, a featured video lecture, and a list of courses generated from dummy data using JavaScript. A separate courses page lets users view all courses and "enroll" using local storage.
+
+## Usage
+
+Open `index.html` in your browser to see the landing page or `courses.html` to browse all courses. The pages are static and use the included CSS and JavaScript files.
+
+Feel free to extend or customize the content for your own needs.

--- a/script.js
+++ b/script.js
@@ -1,0 +1,23 @@
+// Dummy course data
+const courses = [
+  { id: 1, title: 'Web Development', description: 'Learn to build websites with HTML, CSS, and JS.' },
+  { id: 2, title: 'Data Science', description: 'An introduction to data analysis and visualization.' },
+  { id: 3, title: 'Machine Learning', description: 'Explore the fundamentals of machine learning algorithms.' }
+];
+
+// expose courses globally so other pages can reuse the data
+window.courses = courses;
+
+function renderCourses() {
+  const container = document.getElementById('courseContainer');
+  if (!container) return; // allow script reuse on other pages
+  courses.forEach(course => {
+    const li = document.createElement('li');
+    li.className = 'course-item';
+    li.innerHTML = `<h3>${course.title}</h3><p>${course.description}</p>`;
+    container.appendChild(li);
+  });
+}
+
+// Initialize course rendering when DOM is ready
+window.addEventListener('DOMContentLoaded', renderCourses);

--- a/style.css
+++ b/style.css
@@ -1,0 +1,63 @@
+body {
+    font-family: Arial, Helvetica, sans-serif;
+    margin: 0;
+    padding: 0;
+    background-color: #f9f9f9;
+    color: #333;
+}
+
+.navbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1rem 2rem;
+    background-color: #004080;
+    color: white;
+}
+
+.nav-links {
+    list-style: none;
+    display: flex;
+    gap: 1rem;
+}
+
+.nav-links a {
+    color: white;
+    text-decoration: none;
+}
+
+.hero {
+    background: #e0e0e0;
+    padding: 4rem 2rem;
+    text-align: center;
+}
+
+.courses {
+    padding: 2rem;
+    text-align: center;
+}
+
+.course-list {
+    padding: 2rem;
+}
+
+.course-item {
+    background-color: white;
+    border-radius: 8px;
+    padding: 1rem;
+    margin-bottom: 1rem;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.enroll-btn {
+    background-color: #004080;
+    color: white;
+    border: none;
+    padding: 0.5rem 1rem;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.enroll-btn:hover {
+    background-color: #002a5c;
+}


### PR DESCRIPTION
## Summary
- add a new `courses.html` page for browsing all courses
- implement enrollment logic in `courses.js` using local storage
- expose course data globally in `script.js`
- update navigation links and styles
- document how to open both pages in the README

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_b_6870b958be248321abec18d0380f9863